### PR TITLE
feat: Add support for format arguments in Error class

### DIFF
--- a/src/Core.Utilities/Errors/Error.cs
+++ b/src/Core.Utilities/Errors/Error.cs
@@ -30,10 +30,12 @@ public record Error : IEquatable<Error>
     /// <param name="errorType">The type of the error.</param>
     /// <param name="code">The code of the error.</param>
     /// <param name="message">The custom message of the error.</param>
-    public Error(ErrorType errorType, string code, string? message = null)
+    /// <param name="formatArgs">Optional. An array of arguments that are used to format the error message. If no arguments are provided, the message will be returned as-is.</param>
+    public Error(ErrorType errorType, string code, string? message = null, string[]? formatArgs = null)
         : this(errorType, code)
     {
         _customMessage = message;
+        _formatArgs = formatArgs ?? [];
     }
 
     /// <summary>
@@ -45,9 +47,23 @@ public record Error : IEquatable<Error>
     /// Gets the custom message of the error.
     /// If a custom message is not set, the message is dynamically retrieved from the resource manager based on the code and current culture.
     /// </summary>
-    public string Message => _customMessage ?? ErrorResourceManager.GetString(Code);
+    public string Message => GetMessage();
+
+    private string GetMessage()
+    {
+        string message = _customMessage ?? ErrorResourceManager.GetString(Code) ?? string.Empty;
+        try
+        {
+            return string.Format(message, _formatArgs ?? []);
+        }
+        catch (Exception)
+        {
+            return message;
+        }
+    }
 
     private readonly string? _customMessage;
+    private readonly string[]? _formatArgs;
 
     /// <summary>
     /// Gets the type of the error.

--- a/tests/Core.Utilities.Tests/Errors/ErrorTests.cs
+++ b/tests/Core.Utilities.Tests/Errors/ErrorTests.cs
@@ -97,4 +97,55 @@ public class ErrorTests : IDisposable
         Assert.Equal("Validation description", validation.Message);
         Assert.Equal(ErrorType.Validation, validation.Type);
     }
+
+    [Fact]
+    public void Error_Message_ShouldReturnCustomMessage_WhenCustomMessageIsProvided()
+    {
+        // Arrange
+        var errorType = ErrorType.Validation;
+        var code = "CustomCode";
+        var customMessage = "Custom error message";
+        var error = new Error(errorType, code, customMessage);
+
+        // Act
+        var message = error.Message;
+
+        // Assert
+        Assert.Equal(customMessage, message);
+    }
+
+    [Fact]
+    public void Error_Message_ShouldReturnFormattedMessage_WhenFormatArgsAreProvided()
+    {
+        // Arrange
+        var errorType = ErrorType.Validation;
+        var code = "FormattedCode";
+        var errorMessage = "Message with {0} and {1}";
+        var formatArgs = new string[] { "arg1", "arg2" };
+        var error = new Error(errorType, code, errorMessage, formatArgs);
+
+        // Act
+        var message = error.Message;
+
+        // Assert
+        var expectedMessage = "Message with arg1 and arg2";
+        Assert.Equal(expectedMessage, message);
+    }
+
+    [Fact]
+    public void Error_Message_ShouldReturnUnformattedMessage_WhenFormatExceptionThrows()
+    {
+        // Arrange
+        var errorType = ErrorType.Validation;
+        var code = "FormattedCode";
+        var errorMessage = "Message with {} and {1}";
+        var formatArgs = new string[] { "arg1", "arg2" };
+        var error = new Error(errorType, code, errorMessage, formatArgs);
+
+        // Act
+        var message = error.Message;
+
+        // Assert
+        Assert.Equal(errorMessage, message);
+    }
 }


### PR DESCRIPTION
feat: Add support for format arguments in Error class

- Updated the `Error` class to support dynamic message formatting using `String.Format`.
- Added `formatArgs` parameter to the constructor to allow for custom placeholders in error messages.
- Modified the `Message` property to use `String.Format` with `_customMessage` or the resource manager string, ensuring no `null` values are used and format exceptions are catched
